### PR TITLE
Add environment-specific GKE options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ min_node_count = 1
 max_node_count = 4
 ```
 
+Additional optional variables allow customizing the network and node settings per environment:
+
+```hcl
+network_name          = "my-vpc"
+subnetwork_name       = "my-subnet"
+ip_cidr_range         = "10.0.0.0/16"
+cluster_machine_type  = "e2-medium"
+cluster_disk_size_gb  = 50
+node_pool_machine_type = "e2-medium"
+node_pool_disk_size_gb = 50
+```
+
+These variables make it possible to fully isolate environments by choosing different machine types, disk sizes and network ranges.
+
 ## Deploying `iac-gke`
 
 ```bash
@@ -41,3 +55,4 @@ terraform apply
 cd cloud_gratis
 docker compose up -d
 ```
+

--- a/iac-gke/envs/dev/main.tf
+++ b/iac-gke/envs/dev/main.tf
@@ -9,4 +9,11 @@ module "gke" {
   min_node_count = var.min_node_count
   max_node_count = var.max_node_count
   master_version = var.master_version
+  network_name        = var.network_name
+  subnetwork_name     = var.subnetwork_name
+  ip_cidr_range       = var.ip_cidr_range
+  cluster_machine_type = var.cluster_machine_type
+  cluster_disk_size_gb = var.cluster_disk_size_gb
+  node_pool_machine_type = var.node_pool_machine_type
+  node_pool_disk_size_gb = var.node_pool_disk_size_gb
 }

--- a/iac-gke/envs/dev/terraform.tfvars
+++ b/iac-gke/envs/dev/terraform.tfvars
@@ -6,3 +6,11 @@ node_count     = 2
 min_node_count = 1
 max_node_count = 4
 master_version = "1.33.0-gke.2248000"
+network_name = "dev-vpc-network"
+subnetwork_name = "dev-vpc-subnetwork"
+ip_cidr_range = "10.10.0.0/16"
+cluster_machine_type = "e2-medium"
+cluster_disk_size_gb = 50
+node_pool_machine_type = "e2-medium"
+node_pool_disk_size_gb = 50
+

--- a/iac-gke/envs/dev/variables.tf
+++ b/iac-gke/envs/dev/variables.tf
@@ -37,3 +37,38 @@ variable "master_version" {
   description = "Version cluster gke"
   type        = string
 }
+
+variable "network_name" {
+  description = "Name of the VPC network"
+  type        = string
+}
+
+variable "subnetwork_name" {
+  description = "Name of the VPC subnetwork"
+  type        = string
+}
+
+variable "ip_cidr_range" {
+  description = "CIDR range for the VPC subnetwork"
+  type        = string
+}
+
+variable "cluster_machine_type" {
+  description = "Machine type for the cluster's default node pool"
+  type        = string
+}
+
+variable "cluster_disk_size_gb" {
+  description = "Disk size in GB for nodes created with the cluster"
+  type        = number
+}
+
+variable "node_pool_machine_type" {
+  description = "Machine type for the managed node pool"
+  type        = string
+}
+
+variable "node_pool_disk_size_gb" {
+  description = "Disk size in GB for the managed node pool"
+  type        = number
+}

--- a/iac-gke/envs/prod/main.tf
+++ b/iac-gke/envs/prod/main.tf
@@ -9,4 +9,11 @@ module "gke" {
   min_node_count = var.min_node_count
   max_node_count = var.max_node_count
   master_version = var.master_version
+  network_name        = var.network_name
+  subnetwork_name     = var.subnetwork_name
+  ip_cidr_range       = var.ip_cidr_range
+  cluster_machine_type = var.cluster_machine_type
+  cluster_disk_size_gb = var.cluster_disk_size_gb
+  node_pool_machine_type = var.node_pool_machine_type
+  node_pool_disk_size_gb = var.node_pool_disk_size_gb
 }

--- a/iac-gke/envs/prod/terraform.tfvars
+++ b/iac-gke/envs/prod/terraform.tfvars
@@ -6,3 +6,11 @@ node_count     = 3
 min_node_count = 2
 max_node_count = 6
 master_version = "1.33.0-gke.2248000"
+network_name = "prod-vpc-network"
+subnetwork_name = "prod-vpc-subnetwork"
+ip_cidr_range = "10.20.0.0/16"
+cluster_machine_type = "n1-standard-2"
+cluster_disk_size_gb = 100
+node_pool_machine_type = "n1-standard-2"
+node_pool_disk_size_gb = 100
+

--- a/iac-gke/envs/prod/variables.tf
+++ b/iac-gke/envs/prod/variables.tf
@@ -37,3 +37,38 @@ variable "master_version" {
   description = "Version cluster gke"
   type        = string
 }
+
+variable "network_name" {
+  description = "Name of the VPC network"
+  type        = string
+}
+
+variable "subnetwork_name" {
+  description = "Name of the VPC subnetwork"
+  type        = string
+}
+
+variable "ip_cidr_range" {
+  description = "CIDR range for the VPC subnetwork"
+  type        = string
+}
+
+variable "cluster_machine_type" {
+  description = "Machine type for the cluster's default node pool"
+  type        = string
+}
+
+variable "cluster_disk_size_gb" {
+  description = "Disk size in GB for nodes created with the cluster"
+  type        = number
+}
+
+variable "node_pool_machine_type" {
+  description = "Machine type for the managed node pool"
+  type        = string
+}
+
+variable "node_pool_disk_size_gb" {
+  description = "Disk size in GB for the managed node pool"
+  type        = number
+}

--- a/iac-gke/modules/gke/main.tf
+++ b/iac-gke/modules/gke/main.tf
@@ -9,12 +9,12 @@ provider "google-beta" {
 }
 
 resource "google_compute_network" "vpc_network" {
-  name = "vpc-network"
+  name = var.network_name
 }
 
 resource "google_compute_subnetwork" "vpc_subnetwork" {
-  name          = "vpc-subnetwork"
-  ip_cidr_range = "10.0.0.0/16"
+  name          = var.subnetwork_name
+  ip_cidr_range = var.ip_cidr_range
   network       = google_compute_network.vpc_network.name
   region        = var.region
 }
@@ -26,8 +26,8 @@ resource "google_container_cluster" "primary" {
   node_locations     = var.zones
 
   node_config {
-    machine_type = "n1-standard-2" # n1-standard-2
-    disk_size_gb = 50
+    machine_type = var.cluster_machine_type
+    disk_size_gb = var.cluster_disk_size_gb
     oauth_scopes = [
       "https://www.googleapis.com/auth/cloud-platform",
     ]
@@ -51,8 +51,8 @@ resource "google_container_node_pool" "primary_nodes" {
 
   node_config {
     preemptible  = true
-    machine_type = "n1-standard-2" # n1-standard-2 e2-medium
-    # disk_size_gb = 50
+    machine_type = var.node_pool_machine_type
+    disk_size_gb = var.node_pool_disk_size_gb
     oauth_scopes = [
       "https://www.googleapis.com/auth/cloud-platform",
     ]

--- a/iac-gke/modules/gke/variables.tf
+++ b/iac-gke/modules/gke/variables.tf
@@ -46,3 +46,45 @@ variable "master_version" {
   type        = string
   default     = "1.33.0-gke.2248000"
 }
+
+variable "network_name" {
+  description = "Name of the VPC network"
+  type        = string
+  default     = "vpc-network"
+}
+
+variable "subnetwork_name" {
+  description = "Name of the VPC subnetwork"
+  type        = string
+  default     = "vpc-subnetwork"
+}
+
+variable "ip_cidr_range" {
+  description = "CIDR range for the VPC subnetwork"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "cluster_machine_type" {
+  description = "Machine type for the cluster's default node pool"
+  type        = string
+  default     = "n1-standard-2"
+}
+
+variable "cluster_disk_size_gb" {
+  description = "Disk size in GB for nodes created with the cluster"
+  type        = number
+  default     = 50
+}
+
+variable "node_pool_machine_type" {
+  description = "Machine type for the managed node pool"
+  type        = string
+  default     = "n1-standard-2"
+}
+
+variable "node_pool_disk_size_gb" {
+  description = "Disk size in GB for the managed node pool"
+  type        = number
+  default     = 50
+}


### PR DESCRIPTION
## Summary
- parameterize network, subnet, IP range, machine type and disk settings in GKE module
- expose new variables to environments
- document the new variables in README

## Testing
- `terraform fmt -recursive` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684796859f3c8320bd271386dff20e9d