### PR TITLE
Rename n8n directory and remove SSH access

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains small experiments for local development and for provisi
 
 - **cloud_gratis/** - Docker Compose example that runs WordPress and MySQL.
 - **iac-gke/** - Contains all infrastructure code. Inside you'll find a reusable module under `modules/gke` and per-environment configurations in `envs/`.
+- **n8n-aws-docker-k8s/** - Terraform for launching an AWS EC2 instance running n8n with Docker.
 
 ## Terraform Version Requirements
 
@@ -54,5 +55,13 @@ terraform apply
 ```bash
 cd cloud_gratis
 docker compose up -d
+```
+
+## Deploying n8n on AWS
+
+```bash
+cd n8n-aws-docker-k8s/envs/dev
+terraform init
+terraform apply
 ```
 

--- a/n8n-aws-docker-k8s/envs/dev/main.tf
+++ b/n8n-aws-docker-k8s/envs/dev/main.tf
@@ -1,0 +1,6 @@
+module "n8n_instance" {
+  source        = "../../modules/ec2"
+  region        = var.region
+  instance_name = var.instance_name
+  instance_type = var.instance_type
+}

--- a/n8n-aws-docker-k8s/envs/dev/terraform.tfvars
+++ b/n8n-aws-docker-k8s/envs/dev/terraform.tfvars
@@ -1,0 +1,3 @@
+region = "us-east-1"
+instance_name = "n8n-dev"
+instance_type = "t2.micro"

--- a/n8n-aws-docker-k8s/envs/dev/variables.tf
+++ b/n8n-aws-docker-k8s/envs/dev/variables.tf
@@ -1,0 +1,17 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "instance_name" {
+  description = "Name tag for the instance"
+  type        = string
+  default     = "n8n-server"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t2.micro"
+}
+

--- a/n8n-aws-docker-k8s/modules/ec2/main.tf
+++ b/n8n-aws-docker-k8s/modules/ec2/main.tf
@@ -1,0 +1,51 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+resource "aws_security_group" "n8n" {
+  name_prefix = "${var.instance_name}-sg-"
+
+  ingress {
+    description = "n8n"
+    from_port   = 5678
+    to_port     = 5678
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "n8n" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = var.instance_type
+  security_groups = [aws_security_group.n8n.name]
+  user_data     = file("${path.module}/user_data.sh")
+
+  tags = {
+    Name = var.instance_name
+  }
+}
+
+output "public_ip" {
+  value = aws_instance.n8n.public_ip
+}
+
+output "instance_id" {
+  value = aws_instance.n8n.id
+}

--- a/n8n-aws-docker-k8s/modules/ec2/user_data.sh
+++ b/n8n-aws-docker-k8s/modules/ec2/user_data.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+# Install Docker if missing
+if ! command -v docker >/dev/null 2>&1; then
+    yum update -y
+    amazon-linux-extras install docker -y
+    systemctl start docker
+    systemctl enable docker
+fi
+
+# Install Docker Compose if missing
+if ! command -v docker-compose >/dev/null 2>&1; then
+    curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    chmod +x /usr/local/bin/docker-compose
+fi
+
+mkdir -p /opt/n8n
+cat <<'EOC' > /opt/n8n/docker-compose.yml
+version: '3'
+services:
+  n8n:
+    image: n8nio/n8n
+    restart: always
+    ports:
+      - "5678:5678"
+    volumes:
+      - n8n_data:/home/node/.n8n
+volumes:
+  n8n_data:
+EOC
+
+cd /opt/n8n
+/usr/local/bin/docker-compose up -d

--- a/n8n-aws-docker-k8s/modules/ec2/variables.tf
+++ b/n8n-aws-docker-k8s/modules/ec2/variables.tf
@@ -1,0 +1,18 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "instance_name" {
+  description = "Name tag for the instance"
+  type        = string
+  default     = "n8n-server"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t2.micro"
+}
+


### PR DESCRIPTION
## Summary
- rename `n8n-docker-k8s` to `n8n-aws-docker-k8s`
- drop SSH ingress and key pair configuration
- update README references

## Testing
- ❌ `terraform init` *(failed: `terraform` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f0c64e748320b5fde5c90fc60396