### PR TITLE
Add basic VPC networking to n8n module

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,14 @@ terraform init
 terraform apply
 ```
 
+The EC2 module now provisions a VPC with a public subnet, internet gateway and
+route table. Use the following variables to control the network ranges:
+
+```hcl
+vpc_cidr    = "10.0.0.0/16"
+subnet_cidr = "10.0.1.0/24"
+```
+
+After apply, Terraform outputs the VPC ID, subnet ID and the instance's public
+IP address.
+

--- a/n8n-aws-docker-k8s/envs/dev/main.tf
+++ b/n8n-aws-docker-k8s/envs/dev/main.tf
@@ -3,4 +3,6 @@ module "n8n_instance" {
   region        = var.region
   instance_name = var.instance_name
   instance_type = var.instance_type
+  vpc_cidr      = var.vpc_cidr
+  subnet_cidr   = var.subnet_cidr
 }

--- a/n8n-aws-docker-k8s/envs/dev/outputs.tf
+++ b/n8n-aws-docker-k8s/envs/dev/outputs.tf
@@ -1,0 +1,11 @@
+output "instance_public_ip" {
+  value = module.n8n_instance.public_ip
+}
+
+output "vpc_id" {
+  value = module.n8n_instance.vpc_id
+}
+
+output "subnet_id" {
+  value = module.n8n_instance.subnet_id
+}

--- a/n8n-aws-docker-k8s/envs/dev/terraform.tfvars
+++ b/n8n-aws-docker-k8s/envs/dev/terraform.tfvars
@@ -1,3 +1,5 @@
 region = "us-east-1"
 instance_name = "n8n-dev"
 instance_type = "t2.micro"
+vpc_cidr = "10.0.0.0/16"
+subnet_cidr = "10.0.1.0/24"

--- a/n8n-aws-docker-k8s/envs/dev/variables.tf
+++ b/n8n-aws-docker-k8s/envs/dev/variables.tf
@@ -15,3 +15,13 @@ variable "instance_type" {
   default     = "t2.micro"
 }
 
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+}
+
+variable "subnet_cidr" {
+  description = "CIDR block for the subnet"
+  type        = string
+}
+

--- a/n8n-aws-docker-k8s/modules/ec2/main.tf
+++ b/n8n-aws-docker-k8s/modules/ec2/main.tf
@@ -12,8 +12,40 @@ data "aws_ami" "amazon_linux" {
   }
 }
 
+# Basic network resources
+resource "aws_vpc" "n8n" {
+  cidr_block = var.vpc_cidr
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_subnet" "n8n" {
+  vpc_id            = aws_vpc.n8n.id
+  cidr_block        = var.subnet_cidr
+  availability_zone = data.aws_availability_zones.available.names[0]
+}
+
+resource "aws_internet_gateway" "n8n" {
+  vpc_id = aws_vpc.n8n.id
+}
+
+resource "aws_route_table" "n8n" {
+  vpc_id = aws_vpc.n8n.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.n8n.id
+  }
+}
+
+resource "aws_route_table_association" "n8n" {
+  subnet_id      = aws_subnet.n8n.id
+  route_table_id = aws_route_table.n8n.id
+}
+
 resource "aws_security_group" "n8n" {
   name_prefix = "${var.instance_name}-sg-"
+  vpc_id      = aws_vpc.n8n.id
 
   ingress {
     description = "n8n"
@@ -32,10 +64,12 @@ resource "aws_security_group" "n8n" {
 }
 
 resource "aws_instance" "n8n" {
-  ami           = data.aws_ami.amazon_linux.id
-  instance_type = var.instance_type
-  security_groups = [aws_security_group.n8n.name]
-  user_data     = file("${path.module}/user_data.sh")
+  ami                    = data.aws_ami.amazon_linux.id
+  instance_type          = var.instance_type
+  subnet_id              = aws_subnet.n8n.id
+  vpc_security_group_ids = [aws_security_group.n8n.id]
+  associate_public_ip_address = true
+  user_data             = file("${path.module}/user_data.sh")
 
   tags = {
     Name = var.instance_name
@@ -48,4 +82,12 @@ output "public_ip" {
 
 output "instance_id" {
   value = aws_instance.n8n.id
+}
+
+output "vpc_id" {
+  value = aws_vpc.n8n.id
+}
+
+output "subnet_id" {
+  value = aws_subnet.n8n.id
 }

--- a/n8n-aws-docker-k8s/modules/ec2/variables.tf
+++ b/n8n-aws-docker-k8s/modules/ec2/variables.tf
@@ -16,3 +16,15 @@ variable "instance_type" {
   default     = "t2.micro"
 }
 
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "subnet_cidr" {
+  description = "CIDR block for the subnet"
+  type        = string
+  default     = "10.0.1.0/24"
+}
+


### PR DESCRIPTION
## Summary
- add VPC, subnet, gateway and routing to the EC2 module
- expose new `vpc_cidr` and `subnet_cidr` variables
- pass network variables from dev environment and provide outputs
- document new variables and architecture in README

## Testing
- `terraform` not installed in environment, so tests were skipped

------
https://chatgpt.com/codex/tasks/task_e_6848f8b0a700832094b8009fa01a1662