### PR TITLE
Fix n8n terraform module domain variable

### DIFF
--- a/n8n-aws-docker-k8s/envs/dev/outputs.tf
+++ b/n8n-aws-docker-k8s/envs/dev/outputs.tf
@@ -11,11 +11,11 @@ output "subnet_id" {
 }
 
 output "route53_zone_id" {
-  value = aws_route53_zone.public.zone_id
+  value = module.n8n_instance.route53_zone_id
 }
 
 output "route53_record_name" {
-  value = aws_route53_record.root.fqdn
+  value = module.n8n_instance.route53_record_name
 }
 
 output "lb_dns_name" {

--- a/n8n-aws-docker-k8s/modules/ec2/outputs.tf
+++ b/n8n-aws-docker-k8s/modules/ec2/outputs.tf
@@ -17,3 +17,11 @@ output "subnet_id" {
 output "lb_dns_name" {
   value = aws_lb.n8n.dns_name
 }
+
+output "route53_zone_id" {
+  value = aws_route53_zone.public.zone_id
+}
+
+output "route53_record_name" {
+  value = aws_route53_record.root.fqdn
+}

--- a/n8n-aws-docker-k8s/modules/ec2/route53.tf
+++ b/n8n-aws-docker-k8s/modules/ec2/route53.tf
@@ -7,5 +7,5 @@ resource "aws_route53_record" "root" {
   name    = var.domain
   type    = "A"
   ttl     = 300
-  records = [module.n8n_instance.public_ip]
+  records = [aws_eip.n8n.public_ip]
 }

--- a/n8n-aws-docker-k8s/modules/ec2/variables.tf
+++ b/n8n-aws-docker-k8s/modules/ec2/variables.tf
@@ -33,6 +33,11 @@ variable "acm_certificate_arn" {
   type        = string
 }
 
+variable "domain" {
+  description = "Domain for the Route53 hosted zone"
+  type        = string
+}
+
 variable "tags" {
   description = "Tags to apply to created resources"
   type        = map(string)


### PR DESCRIPTION
## Summary
- add missing `domain` variable to EC2 module
- correct Route53 record to use EIP
- expose Route53 outputs from module
- update environment outputs to use module values

## Testing
- `terraform validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b095a80883209c84de23d02dc723