### PR TITLE
Add ACM certificate and DNS validation

### DIFF
--- a/n8n-aws-docker-k8s/envs/dev/main.tf
+++ b/n8n-aws-docker-k8s/envs/dev/main.tf
@@ -7,4 +7,5 @@ module "n8n_instance" {
   subnet_cidrs  = var.subnet_cidrs
   tags                = var.tags
   domain   = var.domain
+  record_name = var.record_name
 }

--- a/n8n-aws-docker-k8s/envs/dev/outputs.tf
+++ b/n8n-aws-docker-k8s/envs/dev/outputs.tf
@@ -21,3 +21,7 @@ output "route53_record_name" {
 output "lb_dns_name" {
   value = module.n8n_instance.lb_dns_name
 }
+
+output "certificate_arn" {
+  value = module.n8n_instance.certificate_arn
+}

--- a/n8n-aws-docker-k8s/envs/dev/variables.tf
+++ b/n8n-aws-docker-k8s/envs/dev/variables.tf
@@ -30,6 +30,12 @@ variable "domain" {
   type        = string
 }
 
+variable "record_name" {
+  description = "Record name for the alias. Leave empty for root"
+  type        = string
+  default     = ""
+}
+
 variable "tags" {
   description = "Tags to apply to created resources"
   type        = map(string)

--- a/n8n-aws-docker-k8s/modules/ec2/acm.tf
+++ b/n8n-aws-docker-k8s/modules/ec2/acm.tf
@@ -1,0 +1,29 @@
+resource "aws_acm_certificate" "ssl" {
+  domain_name       = var.domain
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.ssl.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  zone_id = data.aws_route53_zone.this.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  records = [each.value.record]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "ssl" {
+  certificate_arn         = aws_acm_certificate.ssl.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}

--- a/n8n-aws-docker-k8s/modules/ec2/elb.tf
+++ b/n8n-aws-docker-k8s/modules/ec2/elb.tf
@@ -25,6 +25,7 @@ resource "aws_lb_listener" "https" {
   load_balancer_arn = aws_lb.n8n.arn
   port              = 443
   protocol          = "HTTPS"
+  certificate_arn   = aws_acm_certificate.ssl.arn
 
   default_action {
     type             = "forward"

--- a/n8n-aws-docker-k8s/modules/ec2/outputs.tf
+++ b/n8n-aws-docker-k8s/modules/ec2/outputs.tf
@@ -19,9 +19,14 @@ output "lb_dns_name" {
 }
 
 output "route53_zone_id" {
-  value = aws_route53_zone.public.zone_id
+  value = data.aws_route53_zone.this.zone_id
 }
 
 output "route53_record_name" {
   value = aws_route53_record.root.fqdn
+}
+
+output "certificate_arn" {
+  description = "ARN of the generated SSL certificate"
+  value       = aws_acm_certificate.ssl.arn
 }

--- a/n8n-aws-docker-k8s/modules/ec2/route53.tf
+++ b/n8n-aws-docker-k8s/modules/ec2/route53.tf
@@ -1,10 +1,11 @@
-resource "aws_route53_zone" "public" {
-  name = var.domain
+data "aws_route53_zone" "this" {
+  name         = var.domain
+  private_zone = false
 }
 
 resource "aws_route53_record" "root" {
-  zone_id = aws_route53_zone.public.zone_id
-  name    = var.domain
+  zone_id = data.aws_route53_zone.this.zone_id
+  name    = var.record_name != "" ? var.record_name : data.aws_route53_zone.this.name
   type    = "A"
 
   alias {
@@ -13,11 +14,3 @@ resource "aws_route53_record" "root" {
     evaluate_target_health = true
   }
 }
-
-# resource "aws_route53_record" "root" {
-#   zone_id = aws_route53_zone.public.zone_id
-#   name    = var.domain
-#   type    = "A"
-#   ttl     = 300
-#   records = [aws_eip.n8n.public_ip]
-# }

--- a/n8n-aws-docker-k8s/modules/ec2/variables.tf
+++ b/n8n-aws-docker-k8s/modules/ec2/variables.tf
@@ -34,6 +34,12 @@ variable "domain" {
   type        = string
 }
 
+variable "record_name" {
+  description = "Record name for the alias. Leave empty to use the zone root"
+  type        = string
+  default     = ""
+}
+
 variable "tags" {
   description = "Tags to apply to created resources"
   type        = map(string)


### PR DESCRIPTION
## Summary
- create ACM certificate and DNS validation resources
- parameterize record name and expose certificate ARN
- reference existing Route53 zone instead of creating one
- attach SSL certificate to the load balancer

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6849dbb984588320bc002eea3def6887