### PR TITLE
Fix security group self reference

### DIFF
--- a/n8n-aws-docker-k8s/modules/ec2/security_group.tf
+++ b/n8n-aws-docker-k8s/modules/ec2/security_group.tf
@@ -11,11 +11,11 @@ resource "aws_security_group" "n8n" {
   }
 
   ingress {
-    description     = "Tráfico desde el ALB a instancia"
-    from_port       = 80
-    to_port         = 80
-    protocol        = "tcp"
-    security_groups = [aws_security_group.n8n.id]
+    description = "Tráfico desde el ALB a instancia"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    self        = true
   }
 
   egress {


### PR DESCRIPTION
## Summary
- allow n8n instances to talk to themselves by setting `self = true`

## Testing
- `terraform` was not found so no fmt/validate run

------
https://chatgpt.com/codex/tasks/task_e_6849e113e03c8320b4e799f81bd0404e