### PR TITLE
Fix route53 zone references

### DIFF
--- a/n8n-aws-docker-k8s/modules/ec2/acm.tf
+++ b/n8n-aws-docker-k8s/modules/ec2/acm.tf
@@ -16,7 +16,7 @@ resource "aws_route53_record" "cert_validation" {
     }
   }
 
-  zone_id = data.aws_route53_zone.this.zone_id
+  zone_id = aws_route53_zone.public.zone_id
   name    = each.value.name
   type    = each.value.type
   records = [each.value.record]

--- a/n8n-aws-docker-k8s/modules/ec2/outputs.tf
+++ b/n8n-aws-docker-k8s/modules/ec2/outputs.tf
@@ -19,7 +19,7 @@ output "lb_dns_name" {
 }
 
 output "route53_zone_id" {
-  value = data.aws_route53_zone.this.zone_id
+  value = aws_route53_zone.public.zone_id
 }
 
 output "route53_record_name" {

--- a/n8n-aws-docker-k8s/modules/ec2/route53.tf
+++ b/n8n-aws-docker-k8s/modules/ec2/route53.tf
@@ -1,14 +1,10 @@
 resource "aws_route53_zone" "public" {
   name = var.domain
 }
-data "aws_route53_zone" "this" {
-  name         = var.domain
-  private_zone = false
-}
 
 resource "aws_route53_record" "root" {
-  zone_id = data.aws_route53_zone.this.zone_id
-  name    = var.record_name != "" ? var.record_name : data.aws_route53_zone.this.name
+  zone_id = aws_route53_zone.public.zone_id
+  name    = var.record_name != "" ? var.record_name : aws_route53_zone.public.name
   type    = "A"
 
   alias {


### PR DESCRIPTION
## Summary
- clean up Route53 zone data reference
- update cert validation and root record to reference created zone
- expose created hosted zone ID

## Testing
- `terraform fmt -check n8n-aws-docker-k8s/modules/ec2/route53.tf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e10a515883209c5ba4dd16a1a79a